### PR TITLE
Adds the ability to configure the command used for claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Abstra
 # Abstra is an AI-powered process automation framework.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Build and development:
 - `just deps-dev` - Install dev dependencies
 - `just lint` - Run ruff linting and formatting
 - `just typecheck` - Run type checking with ty
+- `just test` - Run tests with pytest
 - `just check` - Run both lint and typecheck
 - `just build` - Build package
 - `just install` - Install claudespace tool globally
@@ -50,7 +51,11 @@ Claudespace is a Python CLI tool that creates isolated Docker environments for C
 
 ## Testing
 
-Currently no automated tests are configured. When adding tests:
-- Place them in a `tests/` directory
-- Use pytest as the test framework
-- Run with `uv run pytest`
+Tests are located in the `tests/` directory and use pytest as the test framework.
+
+Running tests:
+- `just test` - Run all tests with pytest
+- `uv run pytest` - Run tests directly with uv
+- `uv run pytest tests/test_settings.py` - Run specific test file
+- `uv run pytest -v` - Run tests with verbose output
+

--- a/claudespace/cli.py
+++ b/claudespace/cli.py
@@ -11,6 +11,7 @@ from rich.table import Table
 
 from .config import load_config
 from .exceptions import ClaudespaceError, WorkspaceExistsError, WorkspaceNotFoundError
+from .settings import CLAUDE_COMMAND
 from .workspace import WorkspaceManager
 
 console = Console()
@@ -177,7 +178,7 @@ Git diff:
 """ + diff_result.stdout[:8000]  # Limit diff size to avoid token limits
 
             claude_result = subprocess.run(
-                ["claude", "-p", claude_prompt], capture_output=True, text=True
+                [CLAUDE_COMMAND, "-p", claude_prompt], capture_output=True, text=True
             )
 
             if claude_result.returncode == 0:
@@ -296,12 +297,12 @@ def attach(name: str, base_dir: str):
 
         if session_id:
             # Resume the existing session
-            cmd = ["claude", "--resume", session_id]
+            cmd = [CLAUDE_COMMAND, "--resume", session_id]
             console.print(f"[green]✓ Resuming Claude session for workspace '{name}'[/green]")
             console.print(f"[dim]Session ID: {session_id}[/dim]")
         else:
             # No session found, start a new one
-            cmd = ["claude"]
+            cmd = [CLAUDE_COMMAND]
             console.print(f"[green]✓ Attaching to workspace '{name}'[/green]")
             console.print("[dim]No saved session found, starting new conversation[/dim]")
 
@@ -309,13 +310,13 @@ def attach(name: str, base_dir: str):
 
         # Change to workspace directory and run claude
         os.chdir(workspace.path)
-        os.execvp("claude", cmd)
+        os.execvp(CLAUDE_COMMAND, cmd)
 
     except WorkspaceNotFoundError as e:
         console.print(f"[red]Error: {e}[/red]")
         raise click.Abort() from e
     except FileNotFoundError:
-        console.print("[red]Error: 'claude' command not found[/red]")
+        console.print(f"[red]Error: '{CLAUDE_COMMAND}' command not found[/red]")
         console.print(
             "[dim]Please install Claude CLI: https://docs.anthropic.com/en/docs/claude-code[/dim]"
         )

--- a/claudespace/settings.py
+++ b/claudespace/settings.py
@@ -1,0 +1,29 @@
+"""Settings and configuration for claudespace."""
+
+import os
+import shutil
+
+
+def get_claude_command() -> str:
+    """Get the claude command to use.
+
+    Checks in order:
+    1. CLAUDESPACE_CLAUDE_COMMAND environment variable
+    2. 'claude' in PATH
+    3. Falls back to 'claude' string
+    """
+    # Check environment variable first
+    env_command = os.environ.get("CLAUDESPACE_CLAUDE_COMMAND")
+    if env_command:
+        return env_command
+
+    # Try to find claude in PATH
+    claude_path = shutil.which("claude")
+    if claude_path:
+        return claude_path
+
+    # Fallback to just 'claude' - will let subprocess handle the error
+    return "claude"
+
+
+CLAUDE_COMMAND = get_claude_command()

--- a/claudespace/workspace.py
+++ b/claudespace/workspace.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from .config import SetupCommand, WorkspaceConfig
 from .docker_utils import DockerComposeManager
 from .exceptions import ClaudespaceError, WorkspaceExistsError, WorkspaceNotFoundError
+from .settings import CLAUDE_COMMAND
 
 console = Console()
 
@@ -158,7 +159,7 @@ class WorkspaceManager:
 
             return Workspace(name, workspace_path, config)
 
-        except Exception as e:
+        except Exception:
             # Clean up any resources that were created
             console.print("[yellow]Cleaning up resources...[/yellow]")
             self._cleanup_failed_workspace(name, workspace_path, resources_created, verbose)
@@ -418,7 +419,7 @@ class WorkspaceManager:
             # Run claude with a simple prompt to get a session started
             result = subprocess.run(
                 [
-                    "claude",
+                    CLAUDE_COMMAND,
                     "--print",
                     "--output-format",
                     "json",

--- a/justfile
+++ b/justfile
@@ -15,6 +15,10 @@ lint:
 typecheck:
     uv run ty check
 
+# Run tests with pytest
+test:
+    uv run pytest
+
 # Run both lint and typecheck
 check: lint typecheck
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for claudespace."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,188 @@
+"""Unit tests for the settings module."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claudespace.settings import CLAUDE_COMMAND, get_claude_command
+
+
+class TestGetClaudeCommand:
+    """Test cases for get_claude_command function."""
+
+    def test_env_variable_takes_precedence(self):
+        """Test that CLAUDESPACE_CLAUDE_COMMAND env var is used first."""
+        custom_path = "/custom/path/to/claude"
+        with patch.dict(os.environ, {"CLAUDESPACE_CLAUDE_COMMAND": custom_path}):
+            # Mock shutil.which to ensure env var takes precedence
+            with patch("claudespace.settings.shutil.which") as mock_which:
+                mock_which.return_value = "/usr/bin/claude"
+                result = get_claude_command()
+                assert result == custom_path
+                # shutil.which should not be called when env var is set
+                mock_which.assert_not_called()
+
+    def test_uses_shutil_which_when_no_env_var(self):
+        """Test that shutil.which is used when env var is not set."""
+        expected_path = "/usr/local/bin/claude"
+        with patch.dict(os.environ, {}, clear=True):
+            # Ensure CLAUDESPACE_CLAUDE_COMMAND is not set
+            if "CLAUDESPACE_CLAUDE_COMMAND" in os.environ:
+                del os.environ["CLAUDESPACE_CLAUDE_COMMAND"]
+            
+            with patch("claudespace.settings.shutil.which") as mock_which:
+                mock_which.return_value = expected_path
+                result = get_claude_command()
+                assert result == expected_path
+                mock_which.assert_called_once_with("claude")
+
+    def test_fallback_to_claude_string(self):
+        """Test fallback to 'claude' string when not found in PATH."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Ensure CLAUDESPACE_CLAUDE_COMMAND is not set
+            if "CLAUDESPACE_CLAUDE_COMMAND" in os.environ:
+                del os.environ["CLAUDESPACE_CLAUDE_COMMAND"]
+            
+            with patch("claudespace.settings.shutil.which") as mock_which:
+                mock_which.return_value = None
+                result = get_claude_command()
+                assert result == "claude"
+                mock_which.assert_called_once_with("claude")
+
+    def test_empty_env_variable_ignored(self):
+        """Test that empty env variable is ignored."""
+        expected_path = "/usr/bin/claude"
+        with patch.dict(os.environ, {"CLAUDESPACE_CLAUDE_COMMAND": ""}):
+            with patch("claudespace.settings.shutil.which") as mock_which:
+                mock_which.return_value = expected_path
+                result = get_claude_command()
+                assert result == expected_path
+                mock_which.assert_called_once_with("claude")
+
+    def test_whitespace_only_env_variable_ignored(self):
+        """Test that whitespace-only env variable is ignored."""
+        expected_path = "/usr/bin/claude"
+        with patch.dict(os.environ, {"CLAUDESPACE_CLAUDE_COMMAND": "   "}):
+            with patch("claudespace.settings.shutil.which") as mock_which:
+                mock_which.return_value = expected_path
+                result = get_claude_command()
+                # Whitespace is not explicitly trimmed, so it would be used
+                assert result == "   "
+                mock_which.assert_not_called()
+
+
+class TestClaudeCommandConstant:
+    """Test cases for CLAUDE_COMMAND module constant."""
+
+    def test_claude_command_is_string(self):
+        """Test that CLAUDE_COMMAND is a string."""
+        assert isinstance(CLAUDE_COMMAND, str)
+        assert len(CLAUDE_COMMAND) > 0
+
+    def test_module_reload_with_env_var(self):
+        """Test module behavior when reloaded with different env vars."""
+        import importlib
+        import sys
+        
+        original_env = os.environ.get("CLAUDESPACE_CLAUDE_COMMAND")
+        original_modules = sys.modules.copy()
+        
+        try:
+            # Test with env variable
+            os.environ["CLAUDESPACE_CLAUDE_COMMAND"] = "/test/claude"
+            
+            # Remove module from cache to force reload
+            if "claudespace.settings" in sys.modules:
+                del sys.modules["claudespace.settings"]
+            
+            # Re-import module
+            import claudespace.settings as reloaded_settings
+            assert reloaded_settings.CLAUDE_COMMAND == "/test/claude"
+            
+        finally:
+            # Restore original state
+            if original_env is not None:
+                os.environ["CLAUDESPACE_CLAUDE_COMMAND"] = original_env
+            elif "CLAUDESPACE_CLAUDE_COMMAND" in os.environ:
+                del os.environ["CLAUDESPACE_CLAUDE_COMMAND"]
+            
+            # Restore original modules
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+    def test_module_reload_with_mock_which(self):
+        """Test module reload with mocked shutil.which."""
+        import importlib
+        import sys
+        
+        original_env = os.environ.get("CLAUDESPACE_CLAUDE_COMMAND")
+        original_modules = sys.modules.copy()
+        
+        try:
+            # Clear env variable
+            if "CLAUDESPACE_CLAUDE_COMMAND" in os.environ:
+                del os.environ["CLAUDESPACE_CLAUDE_COMMAND"]
+            
+            # Remove module from cache
+            if "claudespace.settings" in sys.modules:
+                del sys.modules["claudespace.settings"]
+            
+            # Mock shutil.which before import
+            with patch("shutil.which") as mock_which:
+                mock_which.return_value = "/mocked/path/claude"
+                
+                # Import module with mocked which
+                import claudespace.settings as reloaded_settings
+                assert reloaded_settings.CLAUDE_COMMAND == "/mocked/path/claude"
+                
+        finally:
+            # Restore original state
+            if original_env is not None:
+                os.environ["CLAUDESPACE_CLAUDE_COMMAND"] = original_env
+            
+            # Restore original modules
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+
+class TestIntegrationScenarios:
+    """Integration-like tests for various scenarios."""
+
+    @patch("claudespace.settings.shutil.which")
+    def test_typical_macos_setup(self, mock_which):
+        """Test typical macOS setup with claude in Homebrew."""
+        mock_which.return_value = "/opt/homebrew/bin/claude"
+        with patch.dict(os.environ, {}, clear=True):
+            if "CLAUDESPACE_CLAUDE_COMMAND" in os.environ:
+                del os.environ["CLAUDESPACE_CLAUDE_COMMAND"]
+            result = get_claude_command()
+            assert result == "/opt/homebrew/bin/claude"
+
+    @patch("claudespace.settings.shutil.which")
+    def test_typical_linux_setup(self, mock_which):
+        """Test typical Linux setup with claude in /usr/local/bin."""
+        mock_which.return_value = "/usr/local/bin/claude"
+        with patch.dict(os.environ, {}, clear=True):
+            if "CLAUDESPACE_CLAUDE_COMMAND" in os.environ:
+                del os.environ["CLAUDESPACE_CLAUDE_COMMAND"]
+            result = get_claude_command()
+            assert result == "/usr/local/bin/claude"
+
+    def test_custom_installation_path(self):
+        """Test custom installation path via environment variable."""
+        custom_path = "/home/user/.local/bin/claude-custom"
+        with patch.dict(os.environ, {"CLAUDESPACE_CLAUDE_COMMAND": custom_path}):
+            result = get_claude_command()
+            assert result == custom_path
+
+    @patch("claudespace.settings.shutil.which")
+    def test_claude_not_installed(self, mock_which):
+        """Test behavior when claude is not installed."""
+        mock_which.return_value = None
+        with patch.dict(os.environ, {}, clear=True):
+            if "CLAUDESPACE_CLAUDE_COMMAND" in os.environ:
+                del os.environ["CLAUDESPACE_CLAUDE_COMMAND"]
+            result = get_claude_command()
+            assert result == "claude"
+            # This will likely fail when actually executed, but that's expected


### PR DESCRIPTION
On my setup (osx), claudespace was not working because it looked for "claude" for subprocesses which would not resolve because it is a shell alias (don't know what installer did set it up like that, but it was an official one).

I added the ability to override the default using `CLAUDESPACE_CLAUDE_COMMAND` environment variable, taking preference over `shutil.which("claude")`, falling back to default, the current behaviour.