### PR TITLE
Fix workspace destroy leaking Docker resources and failing branch cleanup

### DIFF
--- a/claudespace/docker_utils.py
+++ b/claudespace/docker_utils.py
@@ -152,17 +152,17 @@ class DockerComposeManager:
 
     def down(self, volumes: bool = False):
         """Stop Docker Compose services."""
-        # If compose file doesn't exist, try to stop by project name only
-        if not self.compose_file.exists():
-            console.print("[dim]Compose file not found, skipping Docker cleanup[/dim]")
-            return
-
-        cmd = ["docker", "compose", "-p", self.project_name, "-f", str(self.compose_file), "down"]
+        if self.compose_file.exists():
+            cmd = ["docker", "compose", "-p", self.project_name, "-f", str(self.compose_file), "down"]
+        else:
+            # Compose file missing — tear down by project name only
+            console.print("[dim]Compose file not found, tearing down by project name...[/dim]")
+            cmd = ["docker", "compose", "-p", self.project_name, "down"]
 
         if volumes:
             cmd.append("-v")
 
-        subprocess.run(cmd, cwd=self.workspace_path, check=True)
+        subprocess.run(cmd, check=True)
 
     def is_running(self) -> bool:
         """Check if services are running."""

--- a/claudespace/workspace.py
+++ b/claudespace/workspace.py
@@ -44,27 +44,42 @@ class Workspace:
         """Destroy workspace and Docker resources."""
         console.print("[dim]Stopping Docker services and removing volumes...[/dim]")
         compose = DockerComposeManager(self.path, f"claude_{self.name}")
-        compose.down(volumes=True)
+        try:
+            compose.down(volumes=True)
+        except Exception as e:
+            console.print(f"[yellow]Warning: Docker cleanup failed: {e}[/yellow]")
 
-        # Check if this is a worktree
+        # Check if this is a worktree and get main repo path before removal
         is_worktree = False
+        main_repo_path = None
         if self.path.exists():
             git_file = self.path / ".git"
             # .git is a file in worktrees, not a directory
             is_worktree = git_file.exists() and git_file.is_file()
+            if is_worktree:
+                # Read the .git file to find the main repo
+                # Format: "gitdir: /path/to/main/.git/worktrees/<name>"
+                gitdir_line = git_file.read_text().strip()
+                if gitdir_line.startswith("gitdir:"):
+                    gitdir = gitdir_line.split(":", 1)[1].strip()
+                    # Navigate up from .git/worktrees/<name> to the repo root
+                    main_repo_path = str(Path(gitdir).parent.parent.parent)
 
         if is_worktree:
             console.print(f"[dim]Removing git worktree: {self.path}[/dim]")
-            # Remove the worktree
             subprocess.run(
                 ["git", "worktree", "remove", str(self.path), "--force"],
                 capture_output=True,
                 text=True,
             )
-            # Also remove the branch
             branch_name = f"claude-{self.name}"
             console.print(f"[dim]Removing branch: {branch_name}[/dim]")
-            subprocess.run(["git", "branch", "-D", branch_name], capture_output=True, text=True)
+            subprocess.run(
+                ["git", "branch", "-D", branch_name],
+                capture_output=True,
+                text=True,
+                cwd=main_repo_path,
+            )
         elif self.path.exists():
             console.print(f"[dim]Removing workspace directory: {self.path}[/dim]")
             shutil.rmtree(self.path)


### PR DESCRIPTION
## Summary
- **Docker cleanup**: `DockerComposeManager.down()` no longer returns early when the compose file is missing -- it falls back to project-name-only teardown so containers/networks are always cleaned up
- **Branch deletion**: Resolves the main repo path from the worktree's `.git` file before removal, so `git branch -D` runs from the correct directory
- **Error handling**: Wraps Docker cleanup in try/except to prevent failures from blocking the rest of the destroy flow

## Test plan
- [x] Verified by destroying a worktree-based workspace end-to-end in a previous session
- [ ] Confirm no orphaned Docker containers remain after `claudespace destroy`
- [ ] Confirm the `claude-<name>` branch is deleted after destroy

Generated with [Claude Code](https://claude.com/claude-code)